### PR TITLE
change editor to $EDITOR

### DIFF
--- a/actions/notes/notesedit
+++ b/actions/notes/notesedit
@@ -57,14 +57,14 @@ case $1 in
 		# If file exists edit it else check lsnotes for pointer then edit 
 		# and add to git if commit action file exists
 		if [ -e $TODO_DIR/notes/${PRE}-${NOTE_FILE}.txt ]; then
-			editor $TODO_DIR/notes/${PRE}-${NOTE_FILE}.txt
+			$EDITOR $TODO_DIR/notes/${PRE}-${NOTE_FILE}.txt
 			add $TODO_DIR/notes/${PRE}-${NOTE_FILE}.txt
 			commit $TODO_DIR/notes/${PRE}-${NOTE_FILE}.txt
 		else
 			# If note link in todo.txt exists then edit
 			if [ $(grep -o '[^ ]*note:[^ ]\+' "$TMP_FILE" | grep '^note:' | grep "$1$" | sort -u| \
 				sed "s/^note://g"| grep -c $NOTE_FILE) -ge 1 ] ;then
-				editor $TODO_DIR/notes/${PRE}-${NOTE_FILE}.txt
+				$EDITOR $TODO_DIR/notes/${PRE}-${NOTE_FILE}.txt
 				add $TODO_DIR/notes/${PRE}-${NOTE_FILE}.txt
 				commit $TODO_DIR/notes/${PRE}-${NOTE_FILE}.txt
 			else


### PR DESCRIPTION
It is better to call $EDITOR (set by  from a shell script/system environment) [which is standard on unix, linux and *bsd] rather than 'editor' which requires either a shell function or a alias or a shell script