### PR TITLE
use /usr/bin/env bash rather than /bin/bash

### DIFF
--- a/actions/drobertadams/upgrade/upgrade
+++ b/actions/drobertadams/upgrade/upgrade
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 action=$1
 shift


### PR DESCRIPTION
#!/usr/bin/env bash
 is POSIX compliant.

/bin/bash will not work on non linux systems like BSD which don't have bash installed by default or have bash installed in the correct directory (/usr/local/bin/) 

using #!/usr/bin/env bash will run bash from the correct directory on Linux/*BSD/Unix/Minix/OSX etc