### PR TITLE
update script to use #!/usr/bin/env bash

### DIFF
--- a/actions/drobertadams/daily/daily
+++ b/actions/drobertadams/daily/daily
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 priority=A
 action=$1


### PR DESCRIPTION
#!/usr/bin/env bash
 is POSIX compliant.

/bin/bash will not work on non linux systems like BSD which don't have bash installed by default or have bash installed in the correct directory (/usr/local/bin/) 

using #!/usr/bin/env bash will run bash from the correct directory on Linux/*BSD/Unix/Minix/OSX etc